### PR TITLE
fix: Cloudflare Pagesのデプロイが正常に動作しない

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 VITE_COMPILER_URL=https://ceres.epi.it.matsue-ct.ac.jp/compile
-VITE_BASE_URL=/writer
+VITE_BASE_URL=/
 VITE_WRITER_REPOSITORY_PATH=poporonnet/kanicon-writer-front

--- a/.env.ceres
+++ b/.env.ceres
@@ -1,0 +1,1 @@
+VITE_BASE_URL=/writer

--- a/README.md
+++ b/README.md
@@ -2,3 +2,42 @@
 
 Matz葉がにロボコン マイコン書き込みツール  
 [コンパイルサーバはこちら](https://github.com/poporonnet/kanicc)
+
+## 開発者向け情報
+
+### requires
+
+- Node.js(latest)
+- pnpm(latest)
+
+依存関係のインストール
+
+```bash
+pnpm i
+```
+
+サーバの起動(開発モード)
+```bash
+pnpm dev
+```
+
+ビルド(プロダクション用)
+
+⚠️**デプロイ先がドメイン直下(`/`)でないと動作しません。**  
+⚠️**パスを掘る場合は個別のビルド設定が必要です(ceres用はこの下にあります)。**
+
+```bash
+pnpm build
+```
+
+ビルド(ceres用)
+
+⚠️**デプロイ先が`/writer`でないと動作しません。**
+
+```bash
+pnpm build:ceres
+```
+
+### Authors
+
+see [poporonnet/kcms](https://github.com/poporonnet/kcms?tab=readme-ov-file#authorslicense).

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:ceres": "tsc && vite build --mode ceres",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "format": "eslint src --fix && prettier --write \"src/**/*.{js,jsx,ts,tsx,json,md}\"",


### PR DESCRIPTION
Close #63 

- デフォルトのベースパスを`/`に変更しました
- ceres用のビルドは`build:ceres`で行われるようにしました
- https://github.com/poporonnet/kcmsf#readme を参考にREADMEに開発者向け情報を追加しました